### PR TITLE
Add feature: String from EmailAddress

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,6 +376,12 @@ impl FromStr for EmailAddress {
     }
 }
 
+impl From<EmailAddress> for String {
+    fn from(email: EmailAddress) -> Self {
+        email.0
+    }
+}
+
 impl EmailAddress {
     ///
     /// Determine whether the `address` string is a valid email address. Note this is equivalent to


### PR DESCRIPTION
Implement the` From<EmailAddress>` trait for `String`. This allows moving the underlying String out of EmailAddress without allocating a new one.

Closes #3 