### PR TITLE
Add `EmailAddress::new_unchecked`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,6 +466,25 @@ impl<'de> Deserialize<'de> for EmailAddress {
 
 impl EmailAddress {
     ///
+    /// Creates an `EmailAddress` without checking if the email is valid. Only
+    /// call this method if the address is known to be valid.
+    /// 
+    /// ```
+    /// use std::str::FromStr;
+    /// use email_address::EmailAddress;
+    ///
+    /// let unchecked = "john.doe@example.com";
+    /// let email = EmailAddress::from_str(unchecked).expect("email is not valid");
+    /// let valid_email = String::from(email);
+    /// let email = EmailAddress::new_unchecked(valid_email);
+    /// 
+    /// assert_eq!("John Doe <john.doe@example.com>", email.to_display("John Doe"));
+    /// ```
+    pub fn new_unchecked(address: String) -> Self {
+        Self(address)
+    }
+
+    ///
     /// Determine whether the `address` string is a valid email address. Note this is equivalent to
     /// the following:
     ///


### PR DESCRIPTION
This allows to create the `EmailAddress` struct without needing to validate
the address. This can be used for example if you need to store the address
as a string somewhere and you know that it is a valid email address.

Sorry for another PR, since you already released a new version.