### PR TITLE
Handle a single qoute in local part of email

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -648,7 +648,8 @@ fn parse_local_part(part: &str) -> Result<(), Error> {
     } else if part.len() > LOCAL_PART_MAX_LENGTH {
         Error::LocalPartTooLong.into()
     } else if part.starts_with(DQUOTE) && part.ends_with(DQUOTE) {
-        if part.len() == 2 {
+        // <= to handle `part` = `"` (single quote).
+        if part.len() <= 2 {
             Error::LocalPartEmpty.into()
         } else {
             parse_quoted_local_part(&part[1..part.len() - 1])
@@ -1090,6 +1091,11 @@ mod tests {
     fn test_bad_example_03() {
         expect(
             "\"\"@example.com",
+            Error::LocalPartEmpty,
+            Some("local-part is empty"),
+        );
+        expect(
+            "\"@example.com",
             Error::LocalPartEmpty,
             Some("local-part is empty"),
         );


### PR DESCRIPTION
Previously this would panic because it didn't consider email address where the local part was a single double qoute (DQUOTE).