### PR TITLE
feat: add support for `#![no_std]` environments

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,6 +49,12 @@ jobs:
         command: publish
         args: --package ${{ matrix.package}} --dry-run
 
+    - name: Check publish (no_std)
+      uses: actions-rs/cargo@v1
+      with:
+        command: publish
+        args: --package ${{ matrix.package}} --target x86_64-unknown-none --dry-run
+
       
   check_tests:
     name: Check for test types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = ["serde_support"]
 serde_support = ["serde"]
 
 [dependencies]
-serde = { optional = true, version = "1.0" }
+serde = { optional = true, version = "1.0", default-features = false }
 
 [dev-dependencies]
 claims = "0.7.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ publish = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-default = ["serde_support"]
+default = ["std", "serde_support"]
+std = []
 serde_support = ["serde"]
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,7 +257,6 @@ An informal description can be found on [Wikipedia](https://en.wikipedia.org/wik
 */
 
 #![cfg_attr(not(feature = "std"), no_std)]
-
 #![warn(
     unknown_lints,
     // ---------- Stylistic
@@ -303,12 +302,12 @@ extern crate alloc;
 use std as alloc;
 
 use alloc::borrow::ToOwned;
-use alloc::string::String;
 use alloc::format;
-use core::str::FromStr;
+use alloc::string::String;
+use core::fmt::{Display, Formatter};
 use core::hash::Hash;
-use core::fmt::{Formatter, Display};
 use core::prelude::rust_2018::*;
+use core::str::FromStr;
 use core::write;
 
 #[cfg(feature = "serde_support")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,8 @@ An informal description can be found on [Wikipedia](https://en.wikipedia.org/wik
 
 */
 
+#![no_std]
+
 #![warn(
     unknown_lints,
     // ---------- Stylistic
@@ -295,11 +297,19 @@ An informal description can be found on [Wikipedia](https://en.wikipedia.org/wik
     dyn_drop,
 )]
 
+extern crate alloc;
+
+use alloc::borrow::ToOwned;
+use alloc::string::String;
+use alloc::format;
+use core::str::FromStr;
+use core::hash::Hash;
+use core::fmt::{Formatter, Display};
+use core::prelude::rust_2018::*;
+use core::write;
+
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Serialize, Serializer};
-use std::fmt::{Debug, Display, Formatter};
-use std::hash::Hash;
-use std::str::FromStr;
 
 // ------------------------------------------------------------------------------------------------
 // Public Types
@@ -471,7 +481,7 @@ const MAILTO_URI_PREFIX: &str = "mailto:";
 // ------------------------------------------------------------------------------------------------
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             Error::InvalidCharacter => write!(f, "Invalid character."),
             Error::LocalPartEmpty => write!(f, "Local part is empty."),
@@ -509,9 +519,9 @@ impl Display for Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
-impl<T> From<Error> for std::result::Result<T, Error> {
+impl<T> From<Error> for core::result::Result<T, Error> {
     fn from(err: Error) -> Self {
         Err(err)
     }
@@ -592,7 +602,7 @@ impl Options {
 // ------------------------------------------------------------------------------------------------
 
 impl Display for EmailAddress {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.0)
     }
 }
@@ -618,7 +628,7 @@ impl PartialEq for EmailAddress {
 impl Eq for EmailAddress {}
 
 impl Hash for EmailAddress {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.0.hash(state);
     }
 }
@@ -666,7 +676,7 @@ impl<'de> Deserialize<'de> for EmailAddress {
         impl Visitor<'_> for EmailAddressVisitor {
             type Value = EmailAddress;
 
-            fn expecting(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, fmt: &mut Formatter<'_>) -> core::fmt::Result {
                 fmt.write_str("string containing a valid email address")
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,7 +256,7 @@ An informal description can be found on [Wikipedia](https://en.wikipedia.org/wik
 
 */
 
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #![warn(
     unknown_lints,
@@ -297,7 +297,10 @@ An informal description can be found on [Wikipedia](https://en.wikipedia.org/wik
     dyn_drop,
 )]
 
+#[cfg(not(feature = "std"))]
 extern crate alloc;
+#[cfg(feature = "std")]
+use std as alloc;
 
 use alloc::borrow::ToOwned;
 use alloc::string::String;


### PR DESCRIPTION
Let me know if this interests you, feel free to close if not :)

# Description

I was looking to use this crate with `#![no_std]` but it was not supported. I took a quick look at what it's doing and it doesn't look like it needs `std` at all - just `core` and `alloc`.

However this would bump the MSRV to 1.81.0 for `core::error::Error` so I created a new default feature `std` so this change is only opt-in (unless someone is using `default-features = false` already).

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- successful `cargo check --target x86_64-unknown-none` (also added to CI)

**Environment (please complete the following information):**
 - Platform: `Linux mat 6.9.3-76060903-generic #202405300957~1732141768~22.04~f2697e1 SMP PREEMPT_DYNAMIC Wed N x86_64 x86_64 x86_64 GNU/Linux`
 - Rust
 ```
rustc 1.85.0-nightly (4363f9b6f 2025-01-02)
binary: rustc
commit-hash: 4363f9b6f6d3656d94adbcabba6348a485ef9a56
commit-date: 2025-01-02
host: x86_64-unknown-linux-gnu
release: 1.85.0-nightly
LLVM version: 19.1.6
```
 - Cargo
 ```
cargo 1.85.0-nightly (d73d2caf9 2024-12-31)
release: 1.85.0-nightly
commit-hash: d73d2caf9e41a39daf2a8d6ce60ec80bf354d2a7
commit-date: 2024-12-31
host: x86_64-unknown-linux-gnu
libgit2: 1.8.1 (sys:0.19.0 vendored)
libcurl: 8.9.0-DEV (sys:0.4.74+curl-8.9.0 vendored ssl:OpenSSL/1.1.1w)
ssl: OpenSSL 1.1.1w  11 Sep 2023
os: Pop!_OS 22.4.0 (jammy) [64-bit]
```

# Checklist:

- [x] My code follows the style guidelines of this project (e.g. run `cargo fmt`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes DO NOT require unstable features without prior agreement
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
