### PR TITLE
GitHub Actions Version/Dependency Upgrades

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -192,7 +192,7 @@ jobs:
           token: ${{secrets.CODECOV_TOKEN}}
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
           path: cobertura.xml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Install Rust
       uses: actions-rs/toolchain@v1
@@ -80,7 +80,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Install Rust
       uses: actions-rs/toolchain@v1
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Install Rust
       uses: actions-rs/toolchain@v1
@@ -172,7 +172,7 @@ jobs:
         rust: ["stable"]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -204,7 +204,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Install Rust
       uses: actions-rs/toolchain@v1
@@ -229,7 +229,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Install Rust
       uses: actions-rs/toolchain@v1
@@ -255,7 +255,7 @@ jobs:
       checks: write
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Install Rust
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,19 +35,14 @@ jobs:
       uses: actions/checkout@v5
       
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        profile: minimal
-        override: true
         
     - uses: Swatinem/rust-cache@v2
       
     - name: Check publish
-      uses: actions-rs/cargo@v1
-      with:
-        command: publish
-        args: --package ${{ matrix.package}} --dry-run
+      run: cargo publish --package ${{ matrix.package}} --dry-run
 
       
   check_tests:
@@ -83,25 +78,17 @@ jobs:
       uses: actions/checkout@v5
       
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ matrix.rust }}
-        profile: minimal
-        override: true
         
     - uses: Swatinem/rust-cache@v2
       
     - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --workspace ${{ matrix.test-features }}
+      run: cargo build --workspace ${{ matrix.test-features }}
       
     - name: Test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --workspace ${{ matrix.test-features }}
+      run: cargo test --workspace ${{ matrix.test-features }}
  
       
   benchmarks:
@@ -118,19 +105,14 @@ jobs:
       uses: actions/checkout@v5
       
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ matrix.rust }}
-        profile: minimal
-        override: true
         
     - uses: Swatinem/rust-cache@v2
       
     - name: Run benchmarks with all features
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --workspace --benches --all-features --no-fail-fast
+      run: cargo test --workspace --benches --all-features --no-fail-fast
 
       
   examples:
@@ -144,22 +126,17 @@ jobs:
         rust: ["stable"]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ matrix.rust }}
-        profile: minimal
-        override: true
         
     - uses: Swatinem/rust-cache@v2
       
     - name: Run examples with all features
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --workspace --examples --all-features --no-fail-fast
+      run: cargo test --workspace --examples --all-features --no-fail-fast
 
         
   coverage:   
@@ -175,19 +152,18 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
+      
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
 
       - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: 0.22.0
-          args: --all-features -- --test-threads 1
+        run: cargo tarpaulin --all-features -- --test-threads 1
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1.0.2
+        uses: codecov/codecov-action@v5
         with:
           token: ${{secrets.CODECOV_TOKEN}}
 
@@ -207,21 +183,16 @@ jobs:
       uses: actions/checkout@v5
       
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        profile: minimal
-        override: true
         
     - uses: Swatinem/rust-cache@v2
       
     - name: Generate documentation
-      uses: actions-rs/cargo@v1
       env:
         RUSTDOCFLAGS: -D warnings
-      with:
-        command: doc
-        args: --workspace --all-features --no-deps
+      run: cargo doc --workspace --all-features --no-deps
 
       
   rustfmt:
@@ -232,20 +203,15 @@ jobs:
       uses: actions/checkout@v5
       
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        profile: minimal
-        override: true
         components: rustfmt
               
     - uses: Swatinem/rust-cache@v2
 
     - name: Check formatting
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+      run: cargo fmt --all -- --check
 
       
   clippy:
@@ -258,16 +224,12 @@ jobs:
       uses: actions/checkout@v5
       
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        profile: minimal
-        override: true
         components: clippy
               
     - uses: Swatinem/rust-cache@v2
 
-    - uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --workspace --no-deps --all-features --all-targets -- -D warnings
+    - name: Run Clippy
+      run: cargo clippy --workspace --no-deps --all-features --all-targets -- -D warnings

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -21,7 +21,7 @@ jobs:
       checks: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -24,11 +24,10 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          profile: minimal
-          override: true
+          components: clippy
 
       - uses: actions-rs/audit-check@v1
         with:

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       
     - name: Spell check repository
       uses: crate-ci/typos@master


### PR DESCRIPTION
# Description

Replaces some outdated/deprecated/unmaintained GitHub Actions dependencies with either (1) maintained equivalents or (2) vanilla commands which fulfill the same function. Here is a summary of the changes:

* `actions/checkout` has been bumped to v5 (latest)
* `codecov/codecov-action` has been bumped to v5 (latest)
* All `actions-rs/*` actions have been replaced with the maintained/modern equivalents
   * `actions-rs/toolchain` has been replaced with the maintained and more popular [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain/tree/master) (note: dtolnay's action internally uses the `minimal` profile)
   * `actions-rs/tarpaulin` has been replaced with an inline `cargo install cargo-tarpaulin` followed by an inline `cargo tarpaulin` command
   * `actions-rs/clippy-check` has been replaced with an inline `cargo clippy` command - for this particular change, I referenced [line 61 in this random diff](https://github.com/tauri-apps/tauri/pull/8093/files#diff-e660052642faf374796115bc34f9a87e4ca70ae2ee2f4fd9973895a90113ac61R61) I found online which seems to be pursuing the same kind of refactoring

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested by running the modified/added Cargo commands directly against the repository.

# Checklist:

- [X] My code follows the style guidelines of this project (e.g. run `cargo fmt`)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - N/A?
- [ ] My changes generate no new warnings - TBD pending GitHub Actions execution
- [X] My changes DO NOT require unstable features without prior agreement
- [ ] I have added tests that prove my fix is effective or that my feature works - N/A?
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
