### PR TITLE
Support zeroization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 [features]
 default = ["serde_support"]
 serde_support = ["serde"]
+zeroize = ["dep:zeroize", "dep:zeroize_derive"]
 
 [dependencies]
 serde = { optional = true, version = "1.0" }
+zeroize = { optional = true, version = "1" }
+zeroize_derive = { optional = true, version = "1" }
 
 [dev-dependencies]
 claims = "0.7.1"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Currently, it supports all the RFC ASCII and UTF-8 character set rules as well
 as quoted and unquoted local parts but does not yet support all the productions
 required for SMTP headers; folding whitespace, comments, etc.
 
+## Additional Features
+
+* `serde`: adds `Serialize` and `Deserialize` implementations for `EmailAddress`.
+* `zeroize`: adds `Zeroize` implementation for `EmailAddress`, and ensures that
+  the `EmailAddress` is zeroized when dropped.
+
 ## Example
 
 ```rust


### PR DESCRIPTION
# Description

This PR adds feature-protected zeroization of `EmailAddress` on the base of well-known [zeroize](https://crates.io/crates/zeroize) project:
* the address can be zeroized explicitly,
* its implementation of the `Drop` enforces zeroization.

In addition to just deriving `Zeroize` and `ZeroizeOnDrop`, I checked the code to ensure that with a feature turned on all the temporarily allocated objects are zeroized as well. Finally, I masked the invalid email in the serde error message.

All of this is necessary to support safer wrapper for stricter GDPR compliance, and also enable structures containing `EmailAddress` field to derive `Zeroize` and `ZeroizeOnDrop`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The feature is tested in 3 ways:

- [x] Test the support of the explicit zeroization via `EmailAddress::zeroize(&mut self)` with a feature turned on
- [x] Test the need for drop with a feature turned on (which is a kind of the standard way to ensure `ZeroizeOnDrop` without testing the zeroize by itself.
- [x] Test that with both `zeroize` and `serde_support` turned on, the invalid address string is not leaked into the error mesage

**Environment (please complete the following information):**
 - Platform: [e.g.`uname -a`] 
 `5.15.0-153-generic #163-Ubuntu SMP Thu Aug 7 16:37:18 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux`
 - Rust [e.g.`rustic -vV`] `
 ```shell
 rustc 1.90.0 (1159e78c4 2025-09-14)
binary: rustc
commit-hash: 1159e78c4747b02ef996e55082b704c09b970588
commit-date: 2025-09-14
host: x86_64-unknown-linux-gnu
release: 1.90.0
LLVM version: 20.1.8
```
 - Cargo [e.g.`cargo -vV`]
 ```
 cargo 1.90.0 (840b83a10 2025-07-30)
release: 1.90.0
commit-hash: 840b83a10fb0e039a83f4d70ad032892c287570a
commit-date: 2025-07-30
host: x86_64-unknown-linux-gnu
libgit2: 1.9.1 (sys:0.20.2 vendored)
libcurl: 8.14.1-DEV (sys:0.4.82+curl-8.14.1 vendored ssl:OpenSSL/3.5.0)
ssl: OpenSSL 3.5.0 8 Apr 2025
os: Linux Mint 21.3.0 (virginia) [64-bit]
 ```

# Checklist:

- [x] My code follows the style guidelines of this project (e.g. run `cargo fmt`)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes DO NOT require unstable features without prior agreement
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
