### PR TITLE
Add utoipa for OpenAPI docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 [features]
 default = ["serde_support"]
 serde_support = ["serde"]
+utoipa = ["dep:utoipa"]
 
 [dependencies]
 serde = { optional = true, version = "1.0" }
+utoipa = { optional = true, version = "5.4.0" }
 
 [dev-dependencies]
 claims = "0.8.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -433,6 +433,7 @@ pub struct Options {
 /// independently.
 ///
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema), schema(format = Email, description = ""))]
 pub struct EmailAddress(String);
 
 // ------------------------------------------------------------------------------------------------
@@ -1237,6 +1238,8 @@ mod serde_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "utoipa")]
+    use utoipa::OpenApi;
 
     fn is_valid(address: &str, test_case: Option<&str>) {
         if let Some(test_case) = test_case {
@@ -1913,5 +1916,22 @@ mod tests {
 
         assert_eq!(email, EmailAddress::new_unchecked("simon@Example.com"));
         assert_eq!(email, EmailAddress::new_unchecked("simon@example.COM"));
+    }
+
+    #[cfg(feature = "utoipa")]
+    #[test]
+    // Feature test: GitHub PR: #47
+    fn test_openapi_correct_type() {
+        #[derive(utoipa::OpenApi)]
+        #[openapi(
+            components(schemas(EmailAddress)),
+            info(title = "", description = "", license(), version = "", contact())
+        )]
+        struct ApiDoc;
+
+        assert_eq!(
+            ApiDoc::openapi().to_json().unwrap(),
+            r#"{"openapi":"3.1.0","info":{"title":"","description":"","contact":{},"license":{"name":""},"version":""},"paths":{},"components":{"schemas":{"EmailAddress":{"type":"string","format":"email","description":""}}}}"#
+        );
     }
 }


### PR DESCRIPTION
# Description

I'm using this crate in an HTTP REST JSON API and are busy creating an API documentation using [utoipa](https://crates.io/crates/utoipa) for that. For a strong typing, I'd like to indicate to the generated OpenAPI document that certain fields are on type email. For utoipa to work nicely, every field in a struct must implement `utoipa::ToSchema`. Alternatively, it is also possible to have a loose function defining the Schema of a field. This is very annoying to use for fields like `Option<Vec<EmailAddress>>` or `HashMap<EmailAddress, Something>.

Therefore, I'd like to add an optional feature that derives the necessary `utoipa` Trait and, thus, makes it easier to work with OpenAPI.

I'm not sure if that feature requires a documentation update. I did not find any spots where the `serde` feature is additionally documented, and I assume the feature name is already clear enough. If you think differently, I'll happily add some sentences.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I used it to generate some OpenAPI docs, which worked fine. Additionally, I've added a simple test case that checks if the generated OpenAPI Json is correct.

# Checklist:

- [x] My code follows the style guidelines of this project (e.g. run `cargo fmt`)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes DO NOT require unstable features without prior agreement
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
