### PR TITLE
Fix: handle display-like text in quoted local parts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -944,9 +944,11 @@ fn split_parts(address: &str) -> Result<(&str, &str, &str), Error> {
 }
 
 fn split_display_email(text: &str) -> Result<(&str, &str), Error> {
-    match text.rsplit_once(DISPLAY_SEP) {
+    match find_display_separator(text) {
         None => Ok(("", text)),
-        Some((left, right)) => {
+        Some(index) => {
+            let left = &text[..index];
+            let right = &text[index + DISPLAY_SEP.len()..];
             let right = right.trim();
             if !right.ends_with(DISPLAY_END) {
                 Err(Error::MissingEndBracket)
@@ -958,6 +960,28 @@ fn split_display_email(text: &str) -> Result<(&str, &str), Error> {
             }
         }
     }
+}
+
+fn find_display_separator(text: &str) -> Option<usize> {
+    let mut in_quote = false;
+    let mut escaped = false;
+    let mut separator = None;
+
+    for (index, c) in text.char_indices() {
+        if !in_quote && text[index..].starts_with(DISPLAY_SEP) {
+            separator = Some(index);
+        }
+
+        if escaped {
+            escaped = false;
+        } else if in_quote && c == ESC {
+            escaped = true;
+        } else if c == DQUOTE {
+            in_quote = !in_quote;
+        }
+    }
+
+    separator
 }
 
 fn split_at(address: &str) -> Result<(&str, &str), Error> {
@@ -1372,6 +1396,15 @@ mod tests {
     #[test]
     fn test_good_examples_from_wikipedia_20() {
         is_valid("\"Joe.\\\\Blow\"@example.com", None);
+    }
+
+    #[test]
+    fn test_quoted_local_part_with_display_like_text() {
+        let email = EmailAddress::from_str("\"User <user@example.com>\"@example.com").unwrap();
+
+        assert_eq!(email.display_part(), "");
+        assert_eq!(email.local_part(), "\"User <user@example.com>\"");
+        assert_eq!(email.domain(), "example.com");
     }
 
     #[test]


### PR DESCRIPTION
# Description

Fix parsing for quoted local parts that contain display-name-like text.

Previously, an address such as `"User <user@example.com>"@example.com` could be misinterpreted as display-name syntax because the parser split on ` <` without accounting for quoted local parts. This change makes display-name splitting quote-aware, so ` <...>` inside quotes remains part of the local part.

No new dependencies are required.

Fixes #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added regression test for `"User <user@example.com>"@example.com`
- [x] Ran `cargo fmt --check`
- [x] Ran `cargo test`

**Environment (please complete the following information):**
 - Platform: `Linux yxThinkpadT14G5 6.6.114.1-microsoft-standard-WSL2 #1 SMP PREEMPT_DYNAMIC Mon Dec  1 20:46:23 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux`
 - Rust: 
```rustc 1.97.0-nightly (4b0c9d76a 2026-05-10)
binary: rustc
commit-hash: 4b0c9d76ae7d387229caea55cfa73c280b08b8a7
commit-date: 2026-05-10
host: x86_64-unknown-linux-gnu
release: 1.97.0-nightly
LLVM version: 22.1.4
```
 - Cargo:
```cargo 1.97.0-nightly (a343accce 2026-05-08)
release: 1.97.0-nightly
commit-hash: a343accce8526b128adc517d33348573d22920a3
commit-date: 2026-05-08
host: x86_64-unknown-linux-gnu
libgit2: 1.9.2 (sys:0.20.4 vendored)
libcurl: 8.20.0-DEV (sys:0.4.88+curl-8.20.0 vendored ssl:OpenSSL/3.6.2)
ssl: OpenSSL 3.6.2 7 Apr 2026
os: Ubuntu 24.4.0 (noble) [64-bit]
```

# Checklist:

- [x] My code follows the style guidelines of this project (e.g. run `cargo fmt`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes DO NOT require unstable features without prior agreement
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules